### PR TITLE
Fixes bugs in expect extension "toBeCalledWith" method

### DIFF
--- a/functions/test/pubsub/processUploads_test.js
+++ b/functions/test/pubsub/processUploads_test.js
@@ -67,7 +67,7 @@ describe('receivedAttachments', function() {
           }
         );
         expect(this.imageManipulation.getSize).toBeCalledWith('/tmp/objectId-0.jpeg')
-        expect(this.postsEntity.save).toBeCalledWith('objectId-0', '/images/objectId-0.jpeg', 'objectIds');
+        expect(this.postsEntity.save).toBeCalledWith('objectId-0', '/images/objectId-0.jpeg', 'objectId');
       });
   });
 

--- a/functions/test/pubsub/processUploads_test.js
+++ b/functions/test/pubsub/processUploads_test.js
@@ -67,7 +67,7 @@ describe('receivedAttachments', function() {
           }
         );
         expect(this.imageManipulation.getSize).toBeCalledWith('/tmp/objectId-0.jpeg')
-        expect(this.postsEntity.save).toBeCalledWith('objectId-0', '/images/objectId-0.jpeg', 'objectId');
+        expect(this.postsEntity.save).toBeCalledWith('objectId-0', '/images/objectId-0.jpeg', 'objectIds');
       });
   });
 

--- a/functions/test/setup.js
+++ b/functions/test/setup.js
@@ -6,8 +6,8 @@ expect.extend({
   toBeCalledWith(...expectedArgs) {
     expect.assert(
       this.actual.calledWith(...expectedArgs),
-      "expected %s to have been called with args %s",
-      this.actual,
+      "expected function %s to have been called with args %s",
+      this.actual.displayName,
       ...expectedArgs
     );
 

--- a/functions/test/setup.js
+++ b/functions/test/setup.js
@@ -6,11 +6,10 @@ expect.extend({
   toBeCalledWith(...expectedArgs) {
     expect.assert(
       this.actual.calledWith(...expectedArgs),
-      "expected function %s to have been called with args %s",
+      "Expected function %s to have been called with args %s.",
       this.actual.displayName,
-      ...expectedArgs
-    );
-
+      expectedArgs
+    )
     return this;
   },
 });


### PR DESCRIPTION
There's a bug in the `toBeCalledWith` [expect](https://github.com/mjackson/expect) extension where the error message only displays the first expected argument. Specifically, this occurs when using the spread syntax with %s string formatting. I removed the spread syntax to fix this.

Additionally, the error message was not displaying the name of the function with the failing assertion, and instead displayed only `Function: proxy`. This is fixed by using `this.actual.displayName` instead of `this.actual`.